### PR TITLE
v1.3.0

### DIFF
--- a/bitcask.go
+++ b/bitcask.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 	"sort"
 	"sync"
@@ -26,6 +25,7 @@ const (
 	filerIndexFile string = "index"
 	ttlIndexFile   string = "ttl_index"
 	metadataFile   string = "meta.json"
+	tempIndexFile  string = "index.tmp"
 )
 
 // Stats is a struct returned by Stats() on an open Bitcask instance
@@ -58,7 +58,7 @@ type Bitcask struct {
 	metadata   *metadata
 	repliEmit  repli.Emitter
 	repliRecv  repli.Reciver
-	isMerging  bool
+	merger     *merger
 }
 
 // Stats returns statistics about the database including the number of
@@ -718,158 +718,21 @@ func (b *Bitcask) reopen() error {
 // and deleted keys removes. Duplicate key/value pairs are also removed.
 // Call this function periodically to reclaim disk space.
 func (b *Bitcask) Merge() error {
-	b.mu.RLock()
-	currentMerging := b.isMerging
-	b.mu.RUnlock()
-
-	if currentMerging {
-		return ErrMergeInProgress
-	}
-
-	b.mu.Lock()
-	b.isMerging = true
-	b.mu.Unlock()
-
-	defer func() {
-		b.mu.Lock()
-		b.isMerging = false
-		b.mu.Unlock()
-	}()
-
-	b.mu.Lock()
-	if err := b.closeCurrentFile(); err != nil {
-		b.mu.Unlock()
-		return err
-	}
-	filesToMerge := make([]int32, 0, len(b.datafiles))
-	for id, _ := range b.datafiles {
-		filesToMerge = append(filesToMerge, id)
-	}
-	if err := b.openNewWritableFile(); err != nil {
-		b.mu.Unlock()
-		return err
-	}
-	b.mu.Unlock()
-
-	sort.Slice(filesToMerge, func(i, j int) bool {
-		return filesToMerge[i] < filesToMerge[j]
-	})
-
-	// Temporary merged database path
-	temp, err := os.MkdirTemp(b.path, "merge")
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(temp)
-
-	// Create a merged database
-	mdb, err := Open(temp, withMerge(b.opt))
-	if err != nil {
-		return err
-	}
-	// Rewrite all key/value pairs into merged database
-	// Doing this automatically strips deleted keys and
-	// old key/value pairs
-	if err := func() error {
-		mdb.mu.Lock()
-		defer mdb.mu.Unlock()
-		return b.Fold(func(key []byte) error {
-			v, _ := b.trie.Search(key)
-			filer := v.(indexer.Filer)
-			// if key was updated after start of merge operation, nothing to do
-			if filesToMerge[len(filesToMerge)-1] < filer.FileID {
-				return nil
-			}
-
-			e, err := b.get(key)
-			if err != nil {
-				return err
-			}
-			defer e.Close()
-
-			if err := mdb.putAndIndexLocked(key, e.Value, e.Expiry); err != nil {
-				return err
-			}
-			return nil
-		})
-	}(); err != nil {
-		return err
-	}
-
-	if err := mdb.Sync(); err != nil {
-		return err
-	}
-
-	if err := mdb.Close(); err != nil {
-		return err
-	}
-
-	// no reads and writes till we reopen
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	if err := b.close(); err != nil {
-		return err
-	}
-
-	// Remove data files
-	files, err := os.ReadDir(b.path)
-	if err != nil {
-		return err
-	}
-	for _, file := range files {
-		if file.IsDir() || file.Name() == lockfile {
-			continue
-		}
-		ids, err := datafile.ParseIds([]string{file.Name()})
-		if err != nil {
-			return err
-		}
-		// if datafile was created after start of merge, skip
-		if 0 < len(ids) && filesToMerge[len(filesToMerge)-1] < ids[0] {
-			continue
-		}
-		if err := os.RemoveAll(path.Join(b.path, file.Name())); err != nil {
-			return err
-		}
-	}
-
-	// Rename all merged data files
-	files, err = os.ReadDir(mdb.path)
-	if err != nil {
-		return err
-	}
-	for _, file := range files {
-		// see #225
-		if file.Name() == lockfile {
-			continue
-		}
-		if err := os.Rename(
-			path.Join([]string{mdb.path, file.Name()}...),
-			path.Join([]string{b.path, file.Name()}...),
-		); err != nil {
-			return err
-		}
-	}
-	b.metadata.ReclaimableSpace = 0
-
-	// And finally reopen the database
-	return b.reopen()
+	return b.merger.Merge(b)
 }
 
 // saveIndex saves index and ttl_index currently in RAM to disk
 func (b *Bitcask) saveIndexes() error {
-	tempIdx := "temp_index"
-	if err := b.indexer.Save(b.trie, filepath.Join(b.path, tempIdx)); err != nil {
+	if err := b.indexer.Save(b.trie, filepath.Join(b.path, tempIndexFile)); err != nil {
 		return err
 	}
-	if err := os.Rename(filepath.Join(b.path, tempIdx), filepath.Join(b.path, filerIndexFile)); err != nil {
+	if err := os.Rename(filepath.Join(b.path, tempIndexFile), filepath.Join(b.path, filerIndexFile)); err != nil {
 		return err
 	}
-	if err := b.ttlIndexer.Save(b.ttlIndex, filepath.Join(b.path, tempIdx)); err != nil {
+	if err := b.ttlIndexer.Save(b.ttlIndex, filepath.Join(b.path, tempIndexFile)); err != nil {
 		return err
 	}
-	if err := os.Rename(filepath.Join(b.path, tempIdx), filepath.Join(b.path, ttlIndexFile)); err != nil {
+	if err := os.Rename(filepath.Join(b.path, tempIndexFile), filepath.Join(b.path, ttlIndexFile)); err != nil {
 		return err
 	}
 	return nil
@@ -890,7 +753,14 @@ func (b *Bitcask) isExpired(key []byte) bool {
 	if found != true {
 		return false
 	}
-	return expiry.(time.Time).Before(time.Now().UTC())
+	return b.isExpiredFromTime(expiry.(time.Time))
+}
+
+func (b *Bitcask) isExpiredFromTime(expiry time.Time) bool {
+	if expiry.IsZero() {
+		return false
+	}
+	return expiry.Before(time.Now().UTC())
 }
 
 func (b *Bitcask) repliSource() repli.Source {
@@ -981,6 +851,8 @@ func loadIndexFromDatafile(t art.Tree, ttlIndex art.Tree, df datafile.Datafile) 
 			}
 			return err
 		}
+		defer e.Close()
+
 		if e.ValueSize == 0 {
 			// Tombstone value  (deleted key)
 			t.Delete(e.Key)
@@ -1102,6 +974,7 @@ func Open(path string, funcs ...OptionFunc) (*Bitcask, error) {
 		metadata:   meta,
 		repliEmit:  repliEmitter,
 		repliRecv:  repliReciver,
+		merger:     newMerger(),
 	}
 
 	if err := repliEmitter.Start(bitcask.repliSource(), opt.RepliBindIP, opt.RepliBindPort); err != nil {

--- a/bitcask.go
+++ b/bitcask.go
@@ -30,9 +30,10 @@ const (
 
 // Stats is a struct returned by Stats() on an open Bitcask instance
 type Stats struct {
-	Datafiles int
-	Keys      int
-	Size      int64
+	Datafiles        int
+	Keys             int
+	Size             int64
+	ReclaimableSpace int64
 }
 
 type metadata struct {
@@ -71,12 +72,14 @@ func (b *Bitcask) Stats() (Stats, error) {
 	b.mu.RLock()
 	datafiles := len(b.datafiles)
 	keys := b.trie.Size()
+	rs := b.metadata.ReclaimableSpace
 	b.mu.RUnlock()
 
 	return Stats{
-		Datafiles: datafiles,
-		Keys:      keys,
-		Size:      dirSize,
+		Datafiles:        datafiles,
+		Keys:             keys,
+		Size:             dirSize,
+		ReclaimableSpace: rs,
 	}, nil
 }
 
@@ -878,11 +881,6 @@ func (b *Bitcask) saveMetadata() error {
 		return errors.WithStack(err)
 	}
 	return nil
-}
-
-// Reclaimable returns space that can be reclaimed
-func (b *Bitcask) Reclaimable() int64 {
-	return b.metadata.ReclaimableSpace
 }
 
 // isExpired returns true if a key has expired

--- a/bitcask.go
+++ b/bitcask.go
@@ -753,14 +753,7 @@ func (b *Bitcask) isExpired(key []byte) bool {
 	if found != true {
 		return false
 	}
-	return b.isExpiredFromTime(expiry.(time.Time))
-}
-
-func (b *Bitcask) isExpiredFromTime(expiry time.Time) bool {
-	if expiry.IsZero() {
-		return false
-	}
-	return expiry.Before(time.Now().UTC())
+	return isExpiredFromTime(expiry.(time.Time))
 }
 
 func (b *Bitcask) repliSource() repli.Source {
@@ -769,6 +762,13 @@ func (b *Bitcask) repliSource() repli.Source {
 
 func (b *Bitcask) repliDestination() repli.Destination {
 	return newRepliDestination(b)
+}
+
+func isExpiredFromTime(expiry time.Time) bool {
+	if expiry.IsZero() {
+		return false
+	}
+	return expiry.Before(time.Now().UTC())
 }
 
 func loadDatafiles(opt *option, path string) (map[int32]datafile.Datafile, int32, error) {

--- a/bitcask.go
+++ b/bitcask.go
@@ -311,8 +311,8 @@ func (b *Bitcask) Sift(f func(key []byte) (bool, error)) (err error) {
 
 // DeleteAll deletes all the keys. If an I/O error occurs the error is returned.
 func (b *Bitcask) DeleteAll() (err error) {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
+	b.mu.Lock()
+	defer b.mu.Unlock()
 
 	b.trie.ForEach(func(node art.Node) bool {
 		nodeKey := node.Key()

--- a/bitcask.go
+++ b/bitcask.go
@@ -347,6 +347,11 @@ func (b *Bitcask) Scan(prefix []byte, f func(key []byte) error) (err error) {
 			return true
 		}
 
+		// skip expired
+		if b.isExpired(nodeKey) {
+			return true
+		}
+
 		if err = f(nodeKey); err != nil {
 			return false
 		}

--- a/bitcask_test.go
+++ b/bitcask_test.go
@@ -431,38 +431,38 @@ func TestMetadata(t *testing.T) {
 		assert.Equal(false, db.metadata.IndexUpToDate)
 	})
 	t.Run("Reclaimable", func(t *testing.T) {
-		assert.Equal(int64(0), db.Reclaimable())
+		assert.Equal(int64(0), db.metadata.ReclaimableSpace)
 	})
 	t.Run("ReclaimableAfterNewPut", func(t *testing.T) {
 		assert.NoError(db.PutBytes([]byte("hello"), []byte("world")))
-		assert.Equal(int64(0), db.Reclaimable())
+		assert.Equal(int64(0), db.metadata.ReclaimableSpace)
 	})
 	t.Run("ReclaimableAfterRepeatedPut", func(t *testing.T) {
 		assert.NoError(db.PutBytes([]byte("hello"), []byte("world")))
-		assert.Equal(int64(34), db.Reclaimable())
+		assert.Equal(int64(34), db.metadata.ReclaimableSpace)
 	})
 	t.Run("ReclaimableAfterDelete", func(t *testing.T) {
 		assert.NoError(db.Delete([]byte("hello")))
-		assert.Equal(int64(68), db.Reclaimable())
+		assert.Equal(int64(68), db.metadata.ReclaimableSpace)
 	})
 	t.Run("ReclaimableAfterNonExistingDelete", func(t *testing.T) {
 		assert.NoError(db.Delete([]byte("hello1")))
-		assert.Equal(int64(68), db.Reclaimable())
+		assert.Equal(int64(68), db.metadata.ReclaimableSpace)
 	})
 	t.Run("ReclaimableAfterDeleteAll", func(t *testing.T) {
 		assert.NoError(db.DeleteAll())
-		assert.Equal(int64(130), db.Reclaimable())
+		assert.Equal(int64(130), db.metadata.ReclaimableSpace)
 	})
 	t.Run("ReclaimableAfterMerge", func(t *testing.T) {
 		assert.NoError(db.Merge())
-		assert.Equal(int64(0), db.Reclaimable())
+		assert.Equal(int64(0), db.metadata.ReclaimableSpace)
 	})
 	t.Run("IndexUptoDateAfterMerge", func(t *testing.T) {
 		assert.Equal(true, db.metadata.IndexUpToDate)
 	})
 	t.Run("ReclaimableAfterMergeAndDeleteAll", func(t *testing.T) {
 		assert.NoError(db.DeleteAll())
-		assert.Equal(int64(0), db.Reclaimable())
+		assert.Equal(int64(0), db.metadata.ReclaimableSpace)
 	})
 }
 

--- a/merge.go
+++ b/merge.go
@@ -1,0 +1,313 @@
+package bitcaskdb
+
+import (
+	"os"
+	"path/filepath"
+	goruntime "runtime"
+	"sort"
+	"sync"
+
+	"github.com/pkg/errors"
+	art "github.com/plar/go-adaptive-radix-tree"
+
+	"github.com/octu0/bitcaskdb/datafile"
+	"github.com/octu0/bitcaskdb/indexer"
+)
+
+const (
+	mergeDirPattern string = "merge*"
+)
+
+type merger struct {
+	mutex   *sync.RWMutex
+	merging bool
+}
+
+func (m *merger) isMerging() bool {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	return m.merging
+}
+
+func (m *merger) Merge(b *Bitcask) error {
+	if m.isMerging() {
+		return errors.WithStack(ErrMergeInProgress)
+	}
+
+	m.mutex.Lock()
+	m.merging = true
+	m.mutex.Unlock()
+
+	defer func() {
+		m.mutex.Lock()
+		m.merging = false
+		m.mutex.Unlock()
+	}()
+
+	mergeFileIds, err := m.forwardCurrentDafafile(b)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	temp, err := m.renewMergedDB(b, mergeFileIds)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer temp.Destroy()
+
+	// no reads and writes till we reopen
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if err := b.close(); err != nil {
+		// try recovery
+		if err2 := b.reopen(); err2 != nil {
+			return errors.Wrapf(err2, "failed close() / reopen() cause:%+v", err)
+		}
+		return errors.Wrap(err, "failed to close()")
+	}
+
+	if err := m.moveMerged(b, temp.DBPath()); err != nil {
+		return errors.WithStack(err)
+	}
+
+	b.metadata.ReclaimableSpace = 0
+
+	// And finally reopen the database
+	if err := b.reopen(); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+func (m *merger) forwardCurrentDafafile(b *Bitcask) ([]int32, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	currentFileID, err := b.closeCurrentFile()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	mergeFileIds := make([]int32, 0, len(b.datafiles))
+	for id, _ := range b.datafiles {
+		mergeFileIds = append(mergeFileIds, id)
+	}
+
+	if err := b.openWritableFile(currentFileID + 1); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	sort.Slice(mergeFileIds, func(i, j int) bool {
+		return mergeFileIds[i] < mergeFileIds[j]
+	})
+
+	return mergeFileIds, nil
+}
+
+func (m *merger) renewMergedDB(b *Bitcask, mergeFileIds []int32) (*mergeTempDB, error) {
+	temp, err := openMergeTempDB(b.path, b.opt)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	if err := temp.Merge(b, mergeFileIds); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	if err := temp.SyncAndClose(); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return temp, nil
+}
+
+func (m *merger) moveMerged(b *Bitcask, mergedDBPath string) error {
+	currentFileID := b.curr.FileID()
+
+	if err := m.removeArchive(b, currentFileID); err != nil {
+		return errors.WithStack(err)
+	}
+	if err := m.moveDBFiles(b, mergedDBPath); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+func (m *merger) removeArchive(b *Bitcask, currentFileID int32) error {
+	files, err := os.ReadDir(b.path)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		filename := file.Name()
+		if filename == lockfile {
+			continue
+		}
+
+		ids, err := datafile.ParseIds([]string{filename})
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		if 0 < len(ids) {
+			fileID := ids[0]
+			// keep current
+			if currentFileID == fileID {
+				continue
+			}
+		}
+
+		path := filepath.Join(b.path, filename)
+		if err := os.Remove(path); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+	return nil
+}
+
+func (m *merger) moveDBFiles(b *Bitcask, fromDBPath string) error {
+	// Rename all merged data files
+	files, err := os.ReadDir(fromDBPath)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	for _, file := range files {
+		filename := file.Name()
+		// see https://git.mills.io/prologic/bitcask/issues/225
+		if filename == lockfile {
+			continue
+		}
+		fromFile := filepath.Join(fromDBPath, filename)
+		toFile := filepath.Join(b.path, filename)
+		if err := os.Rename(fromFile, toFile); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+	return nil
+}
+
+func newMerger() *merger {
+	return &merger{
+		mutex:   new(sync.RWMutex),
+		merging: false,
+	}
+}
+
+type mergeTempDB struct {
+	tempDir string
+	mdb     *Bitcask
+}
+
+func (t *mergeTempDB) DBPath() string {
+	return t.mdb.path
+}
+
+func (t *mergeTempDB) DB() *Bitcask {
+	return t.mdb
+}
+
+// Rewrite all key/value pairs into merged database
+// Doing this automatically strips deleted keys and
+// old key/value pairs
+func (t *mergeTempDB) Merge(src *Bitcask, mergeFileIds []int32) error {
+	t.mdb.mu.Lock()
+	defer t.mdb.mu.Unlock()
+
+	m := make(map[int32]datafile.Datafile, len(mergeFileIds))
+	datafiles := make([]datafile.Datafile, len(mergeFileIds))
+	for i, fileID := range mergeFileIds {
+		df, err := datafile.OpenReadonly(
+			datafile.RuntimeContext(src.opt.RuntimeContext),
+			datafile.Path(src.path),
+			datafile.FileID(fileID),
+			datafile.TempDir(src.opt.TempDir),
+			datafile.CopyTempThreshold(src.opt.CopyTempThreshold),
+		)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		datafiles[i] = df
+		m[fileID] = df
+	}
+	defer func() {
+		for _, df := range datafiles {
+			df.Close()
+		}
+	}()
+
+	for _, df := range datafiles {
+		if err := loadIndexFromDatafile(t.mdb.trie, t.mdb.ttlIndex, df); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	if err := t.mergeDatafileLocked(m); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+func (t *mergeTempDB) mergeDatafileLocked(m map[int32]datafile.Datafile) error {
+	var lastErr error
+	t.mdb.trie.ForEach(func(node art.Node) bool {
+		filer := node.Value().(indexer.Filer)
+		e, err := m[filer.FileID].ReadAt(filer.Index, filer.Size)
+		if err != nil {
+			lastErr = errors.WithStack(err)
+			return false
+		}
+		defer e.Close()
+
+		// no merge expired
+		if t.mdb.isExpiredFromTime(e.Expiry) {
+			return true
+		}
+		if err := t.mdb.putAndIndexLocked(e.Key, e.Value, e.Expiry); err != nil {
+			lastErr = errors.WithStack(err)
+			return false
+		}
+		return true
+	})
+	if lastErr != nil {
+		return errors.WithStack(lastErr)
+	}
+	return nil
+}
+
+func (t *mergeTempDB) SyncAndClose() error {
+	if err := t.mdb.Sync(); err != nil {
+		return errors.WithStack(err)
+	}
+	if err := t.mdb.Close(); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+func (t *mergeTempDB) Destroy() {
+	goruntime.SetFinalizer(t, nil) // clear
+	os.RemoveAll(t.tempDir)
+}
+
+func finalizeMergeTempDB(t *mergeTempDB) {
+	t.Destroy()
+}
+
+func openMergeTempDB(basedir string, opt *option) (*mergeTempDB, error) {
+	tempDir, err := os.MkdirTemp(basedir, mergeDirPattern)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	mdb, err := Open(tempDir, withMerge(opt))
+	if err != nil {
+		os.RemoveAll(tempDir)
+		return nil, errors.WithStack(err)
+	}
+	t := &mergeTempDB{tempDir, mdb}
+	goruntime.SetFinalizer(t, finalizeMergeTempDB)
+	return t, nil
+}

--- a/merge.go
+++ b/merge.go
@@ -263,7 +263,7 @@ func (t *mergeTempDB) mergeDatafileLocked(m map[int32]datafile.Datafile) error {
 		defer e.Close()
 
 		// no merge expired
-		if t.mdb.isExpiredFromTime(e.Expiry) {
+		if isExpiredFromTime(e.Expiry) {
 			return true
 		}
 		if err := t.mdb.putAndIndexLocked(e.Key, e.Value, e.Expiry); err != nil {

--- a/merge_test.go
+++ b/merge_test.go
@@ -1,0 +1,112 @@
+package bitcaskdb
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMerge(t *testing.T) {
+	var (
+		db  *Bitcask
+		err error
+	)
+
+	assert := assert.New(t)
+
+	testdir, err := ioutil.TempDir("", "bitcask")
+	assert.NoError(err)
+
+	t.Run("Setup", func(t *testing.T) {
+		t.Run("Open", func(t *testing.T) {
+			db, err = Open(testdir, WithMaxDatafileSize(32))
+			assert.NoError(err)
+		})
+
+		t.Run("PutBytes", func(t *testing.T) {
+			err := db.PutBytes([]byte("foo"), []byte("bar"))
+			assert.NoError(err)
+		})
+
+		s1, err := db.Stats()
+		assert.NoError(err)
+		assert.Equal(0, s1.Datafiles)
+		assert.Equal(1, s1.Keys)
+
+		t.Run("PutBytes", func(t *testing.T) {
+			for i := 0; i < 10; i++ {
+				err := db.PutBytes([]byte("foo"), []byte("bar"))
+				assert.NoError(err)
+			}
+		})
+
+		s2, err := db.Stats()
+		assert.NoError(err)
+		assert.Equal(5, s2.Datafiles)
+		assert.Equal(1, s2.Keys)
+		assert.True(s2.Size > s1.Size)
+
+		t.Run("Merge", func(t *testing.T) {
+			err := db.Merge()
+			assert.NoError(err)
+		})
+
+		s3, err := db.Stats()
+		assert.NoError(err)
+		assert.Equal(2, s3.Datafiles)
+		assert.Equal(1, s3.Keys)
+		assert.True(s3.Size > s1.Size)
+		assert.True(s3.Size < s2.Size)
+
+		t.Run("Sync", func(t *testing.T) {
+			err = db.Sync()
+			assert.NoError(err)
+		})
+
+		t.Run("Close", func(t *testing.T) {
+			err = db.Close()
+			assert.NoError(err)
+		})
+	})
+}
+
+func TestMergeErrors(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Run("RemoveDatabaseDirectory", func(t *testing.T) {
+		testdir, err := ioutil.TempDir("", "bitcask")
+		assert.NoError(err)
+		defer os.RemoveAll(testdir)
+
+		db, err := Open(testdir, WithMaxDatafileSize(32))
+		assert.NoError(err)
+
+		assert.NoError(os.RemoveAll(testdir))
+
+		err = db.Merge()
+		assert.Error(err)
+	})
+}
+
+func TestLockingAfterMerge(t *testing.T) {
+	assert := assert.New(t)
+
+	testdir, err := ioutil.TempDir("", "bitcask")
+	assert.NoError(err)
+
+	db, err := Open(testdir)
+	assert.NoError(err)
+	defer db.Close()
+
+	_, err = Open(testdir)
+	assert.Error(err)
+
+	err = db.Merge()
+	assert.NoError(err)
+
+	// This should still error.
+	_, err = Open(testdir)
+	assert.Error(err)
+}

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package bitcaskdb
 
 const (
 	AppName string = "bitcaskdb"
-	Version string = "1.2.1"
+	Version string = "1.3.0"
 )


### PR DESCRIPTION
Incompatible Changes:
- Remove Reclaimable(), to be included in Stats
- Expired keys will no longer be included in Scan()

Improve:
- Reduce write down time during Merge() operations